### PR TITLE
Allow for a shared authentication header

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,15 @@ urlpatterns = [
 
 ## Configuration
 
-Along with the `PAT_SECRET` value that is required, you can also configure the header and prefix that the
-middleware and REST Framework authentication use for finding and validating the token.
+Along with the `PAT_SECRET` value that is required, you can also configure certain behaviors of the package in your Django
+application settings.
 
 * `PAT_CUSTOM_HEADER` - Sets the HTTP header to check for the token. This defaults to `Authorization`
 * `PAT_CUSTOM_HEADER_PREFIX` - Sets the prefix for the header value. This defaults to `Access-Token`. The middleware
     and the REST authentication expect a space between the prefix and the token value.
+* `PAT_USES_SHARED_HEADER` - If set to True, then the package will not attempt to validate the prefix on the authorization
+    header. This is most useful when different prefixes are used for different types of authentication, but are all sent
+    using the same HTTP header.
 
 ## Implementation Details
 

--- a/src/django_pat/http.py
+++ b/src/django_pat/http.py
@@ -7,6 +7,10 @@ class ParseException(Exception):
         self.msg = msg
 
 
+def uses_shared_header() -> bool:
+    return getattr(settings, "PAT_USES_SHARED_HEADER", False)
+
+
 def get_header():
     return getattr(settings, "PAT_CUSTOM_HEADER", "Authorization")
 
@@ -25,8 +29,12 @@ def parse_header(request):
     if not header_val:
         raise ParseException(gettext("Invalid header"))
 
-    if not header_val.startswith(get_keyword() + " "):
-        raise ParseException(gettext("Invalid header"))
+    starts_with_prefix = header_val.startswith(get_keyword() + " ")
+    if not starts_with_prefix and uses_shared_header():
+        return
+
+    if not starts_with_prefix:
+        raise ParseException(gettext("Invalid authentication type"))
 
     _, token_val = header_val.split(get_keyword() + " ")
 

--- a/src/django_pat/rest_framework/views.py
+++ b/src/django_pat/rest_framework/views.py
@@ -32,7 +32,7 @@ class PersonalAccessTokenViewSet(ModelViewSet):
         return super().get_queryset().filter(user=self.request.user)
 
     def perform_create(self, serializer: CreatePersonalAccessTokenSerializer):  # type: ignore[override]
-        token, plain_text = PersonalAccessToken.objects.create_token(
+        token, plain_text = PersonalAccessToken.objects.create_token(  # type: ignore
             self.request.user,
             serializer.validated_data.get("name"),
             serializer.validated_data.get("description", ""),
@@ -41,7 +41,7 @@ class PersonalAccessTokenViewSet(ModelViewSet):
         # TODO Explore a better way to handle typing here.
         token.plain_text = plain_text  # type: ignore
 
-        serializer.instance = token
+        serializer.instance = token  # type: ignore
 
     def perform_destroy(self, instance: PersonalAccessToken):
         instance.revoke()

--- a/tests/rest_framework/test_auth.py
+++ b/tests/rest_framework/test_auth.py
@@ -53,6 +53,14 @@ class TestPatAuthentication(TestCase):
         self.assertEqual(self.user, found_user)
         self.assertEqual(self.token, found_token)
 
+    @override_settings(PAT_USES_SHARED_HEADER=True)
+    def test_it_supports_a_shared_header(self):
+        req = self.request_factory.get("path", HTTP_AUTHORIZATION=f"Custom-Key {self.token_val}")
+        obj = PatAuthentication()
+        res = obj.authenticate(req)
+
+        self.assertIsNone(res)
+
     def test_it_checks_active_users(self):
         self.user.is_active = False
         self.user.save()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -28,6 +28,11 @@ class TestHeaderParsing(SimpleTestCase):
         req = self.request_factory.get("path", HTTP_AUTHORIZATION="Wrong 1234")
         self.assertRaises(ParseException, parse_header, req)
 
+    @override_settings(PAT_USES_SHARED_HEADER=True)
+    def test_it_supports_a_shared_header_with_different_prefixes(self):
+        req = self.request_factory.get("path", HTTP_AUTHORIZATION="Other-Type 1234")
+        self.assertIsNone(parse_header(req))
+
     @override_settings(PAT_CUSTOM_HEADER="X-Custom-Header")
     def test_it_uses_custom_header(self):
         req = self.request_factory.get("path", HTTP_X_CUSTOM_HEADER="Access-Token 1234")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -52,6 +52,18 @@ class TestPatAuthenticationMiddleware(TestCase):
         req = self.request_factory.get("path", HTTP_AUTHORIZATION=f"Custom-Key {token_val}")
         m(req)
 
+    @override_settings(PAT_USES_SHARED_HEADER=True)
+    def test_it_supports_a_shared_header(self):
+        user = User.objects.create_user("testuser", "test@test.com", "random-insecure-text")
+        token, token_val = PersonalAccessToken.objects.create_token(user, "name")
+
+        def handle(request):
+            self.assertFalse(hasattr(request, "user"))
+
+        m = PatAuthenticationMiddleware(handle)
+        req = self.request_factory.get("path", HTTP_AUTHORIZATION=f"Other-Type {token_val}")
+        m(req)
+
     def test_it_sets_last_used_at(self):
         user = User.objects.create_user("testuser", "test@test.com", "random-insecure-text")
         token, token_val = PersonalAccessToken.objects.create_token(user, "name")


### PR DESCRIPTION
Previously, the authentication would always fail if the prefix on the
HTTP header did not match that expected by this package. This made it
impossible to use the same header, for example `Authorization`, for more
than one type of authentication. This allows for the developer to
configure if this strict check should be enforced.

If the header is defined as a shared header, then receiving a different
prefix than that defined for personal access tokens will not cause an
error, assuming that a different middleware or authenticator will handle
it instead.

The default behavior is the strict check that will throw an error if
a different prefix value is provided.